### PR TITLE
Fixed error message when dialector fails to initialize

### DIFF
--- a/gorm.go
+++ b/gorm.go
@@ -181,7 +181,7 @@ func Open(dialector Dialector, opts ...Option) (db *DB, err error) {
 		err = config.Dialector.Initialize(db)
 
 		if err != nil {
-			if db, err := db.DB(); err == nil {
+			if db, _ := db.DB(); db != nil {
 				_ = db.Close()
 			}
 		}


### PR DESCRIPTION
Let's say we have a problem with DSN which leads to dialector initialize error. However DB connection is not created and for some reason line 184 error provides `nil` even though `db` doesn't exist.

Previously, this code leads to:
`panic: runtime error: invalid memory address or nil pointer dereference`

This fix now doesn't attempt to close non-existant database connection and instead continues, so the proper error is shown.
In my case:
`[error] failed to initialize database, got error default addr for network 'localhost' unknown`